### PR TITLE
feat: enhance ResumoPedidoService status alteration logic and add cor…

### DIFF
--- a/carambolos-api/src/main/java/com/carambolos/carambolosapi/application/usecases/ResumoPedidoService.java
+++ b/carambolos-api/src/main/java/com/carambolos/carambolosapi/application/usecases/ResumoPedidoService.java
@@ -419,8 +419,17 @@ public class ResumoPedidoService {
         if (statusAtual == novoStatus) {
             return false;
         }
-
-        return true;
+        if (statusAtual == StatusEnum.CONCLUIDO) {
+            return false;
+        }
+        return switch (statusAtual) {
+            case PENDENTE -> novoStatus == StatusEnum.PAGO || novoStatus == StatusEnum.CANCELADO;
+            case PAGO -> novoStatus == StatusEnum.CONCLUIDO || novoStatus == StatusEnum.CANCELADO;
+            case CANCELADO -> novoStatus == StatusEnum.PENDENTE
+                    || novoStatus == StatusEnum.PAGO
+                    || novoStatus == StatusEnum.CONCLUIDO;
+            case CONCLUIDO -> false;
+        };
     }
 
     private Double calcularValorPedidoFornada(Integer pedidoFornadaId) {

--- a/carambolos-api/src/test/java/com/carambolos/carambolosapi/application/usecases/ResumoPedidoServiceTest.java
+++ b/carambolos-api/src/test/java/com/carambolos/carambolosapi/application/usecases/ResumoPedidoServiceTest.java
@@ -1,5 +1,6 @@
 package com.carambolos.carambolosapi.application.usecases;
 
+import com.carambolos.carambolosapi.application.exception.EntidadeImprocessavelException;
 import com.carambolos.carambolosapi.domain.entity.ResumoPedido;
 import com.carambolos.carambolosapi.infrastructure.persistence.entity.ProdutoFornada;
 import com.carambolos.carambolosapi.domain.enums.StatusEnum;
@@ -144,6 +145,41 @@ class ResumoPedidoServiceTest {
 
         service.deletarResumoPedido(5);
         assertFalse(rp.getAtivo());
+    }
+
+    @Test
+    void alterarStatus_deConcluido_deveRejeitarQualquerMudanca() {
+        ResumoPedido rp = new ResumoPedido();
+        rp.setStatus(StatusEnum.CONCLUIDO);
+        when(resumoPedidoRepository.findByIdAndIsAtivoTrue(1)).thenReturn(Optional.of(rp));
+
+        assertThrows(
+                EntidadeImprocessavelException.class,
+                () -> service.alterarStatus(1, StatusEnum.PAGO)
+        );
+    }
+
+    @Test
+    void alterarStatus_dePendenteParaConcluido_deveRejeitar() {
+        ResumoPedido rp = new ResumoPedido();
+        rp.setStatus(StatusEnum.PENDENTE);
+        when(resumoPedidoRepository.findByIdAndIsAtivoTrue(1)).thenReturn(Optional.of(rp));
+
+        assertThrows(
+                EntidadeImprocessavelException.class,
+                () -> service.alterarStatus(1, StatusEnum.CONCLUIDO)
+        );
+    }
+
+    @Test
+    void alterarStatus_deCanceladoParaPendente_devePermitir() {
+        ResumoPedido rp = new ResumoPedido();
+        rp.setStatus(StatusEnum.CANCELADO);
+        when(resumoPedidoRepository.findByIdAndIsAtivoTrue(1)).thenReturn(Optional.of(rp));
+        when(resumoPedidoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var updated = service.alterarStatus(1, StatusEnum.PENDENTE);
+        assertEquals(StatusEnum.PENDENTE, updated.getStatus());
     }
 
     @Test


### PR DESCRIPTION
…responding tests

- Updated the status alteration logic to prevent changes from 'CONCLUIDO' and added specific rules for other statuses.
- Introduced tests to validate the new status alteration behavior, ensuring exceptions are thrown for invalid transitions.